### PR TITLE
Prevent player from using +zoom

### DIFF
--- a/crates/flow/hooks/sv_hooks.lua
+++ b/crates/flow/hooks/sv_hooks.lua
@@ -57,6 +57,7 @@ function GM:PlayerSpawn(player)
   player:SetNoDraw(false)
   player:UnLock()
   player:SetNotSolid(false)
+  player:SetCanZoom(false)
 
   hook.run('PostPlayerSpawn', player)
 


### PR DESCRIPTION
As far as I am aware this is bypassable by typing +zoom in the console, but it's better than nothing.