### PR TITLE
Changing parameters to match expected value.

### DIFF
--- a/plugins/characters/plugin/views/cl_character_general.lua
+++ b/plugins/characters/plugin/views/cl_character_general.lua
@@ -98,7 +98,7 @@ function PANEL:Init()
     self.name_random.DoClick = function(btn)
       surface.PlaySound('buttons/blip1.wav')
 
-      self.name_entry:SetText(SCHEMA:get_random_name(self:GetParent().char_data.gender))
+      self.name_entry:SetText(SCHEMA:get_random_name(self:GetParent().char_data))
     end
   end
 


### PR DESCRIPTION
Was causing Lua error:

[ERROR] gamemodes/reborn/schema/cl_schema.lua:10: attempt to index a string value with bad key ('gender' is not part of the string library)

error - [C]:-1
__index - lua/includes/extensions/string.lua:297
3. get_random_name - gamemodes/reborn/schema/cl_schema.lua:10
4. DoClick - gamemodes/flux/plugins/characters/plugin/views/cl_character_general.lua:101
5. unknown - gamemodes/flux/crates/flow/views/base/cl_button.lua:36

Now works without issue.