### PR TITLE
Allowed full horizontal character selection to temporarily solve issue #22

### DIFF
--- a/plugins/characters/plugin/views/cl_character_load.lua
+++ b/plugins/characters/plugin/views/cl_character_load.lua
@@ -10,7 +10,7 @@ function PANEL:Init()
   self.button_close:safe_remove()
 
   self.list = vgui.Create('fl_horizontalbar', self)
-  self.list:SetSize(scrw * 0.5, scrh * 0.5)
+  self.list:SetSize(scrw * 1, scrh * 0.5)
   self.list:SetPos(scrw * 0.5 - self.list:GetWide() * 0.5, scrh * 0.5 - self.list:GetTall() * 0.5)
   self.list:set_centered(true)
 
@@ -46,7 +46,7 @@ function PANEL:rebuild()
 
   for k, v in pairs(characters) do
     self.chars[k] = vgui.Create('fl_character_panel', self)
-    self.chars[k]:SetSize(self.list:GetWide() * 0.25, self.list:GetTall())
+    self.chars[k]:SetSize(self.list:GetWide() * 0.125, self.list:GetTall())
     self.chars[k]:set_character(v)
     self.chars[k]:SetParent(self)
 


### PR DESCRIPTION
Odd numbers cause the centring to be between two panels, instead, we should centre from the first four and add all extra to the right.

I've altered the code so that it fills the entirety of the horizontal space & fits eight characters - which should be more than enough for the majority.

This is only a temporary fix and will need to be given a full patch in the future - as this only supports eight characters before causing the index[1] character to go off the screen to the left, making them unplayable (compared to the previous four.)

If the player owns over 4 characters, they get cut-off/hidden in the character loading screen. #22