### PR TITLE
Turned the respawn command into 2 seperate commands for easier usage

### DIFF
--- a/plugins/admin/plugin/commands/sh_respawn.lua
+++ b/plugins/admin/plugin/commands/sh_respawn.lua
@@ -16,7 +16,6 @@ function COMMAND:on_run(player, targets, spawn_position)
     local positions = { ['stay'] = v.last_pos, ['tp'] = player:GetEyeTraceNoCursor().HitPos }
 
     v:Spawn()
-    v:teleport(positions[spawn_position] or positions['stay'])
     v:notify('notification.respawn', {
       player = player
     })

--- a/plugins/admin/plugin/commands/sh_respawnstay.lua
+++ b/plugins/admin/plugin/commands/sh_respawnstay.lua
@@ -1,0 +1,29 @@
+COMMAND.name = 'Respawnstay'
+COMMAND.description = 'command.respawnstay.description'
+COMMAND.syntax = 'command.respawnstay.syntax'
+COMMAND.permission = 'assistant'
+COMMAND.category = 'permission.categories.player_management'
+COMMAND.arguments = 1
+COMMAND.immunity = true
+COMMAND.aliases = { 'respawn', 'plyrespawn' }
+
+function COMMAND:on_run(player, targets, spawn_position)
+  spawn_position = spawn_position and spawn_position:utf8lower()
+
+  for k, v in ipairs(targets) do
+    if v:Alive() then player:notify('error.respawn') return end
+    
+    local positions = { ['stay'] = v.last_pos, ['tp'] = player:GetEyeTraceNoCursor().HitPos }
+
+    v:Spawn()
+    v:teleport(positions[spawn_position] or positions['stay'])
+    v:notify('notification.respawn', {
+      player = player
+    })
+  end
+
+  self:notify_staff('command.respawn.message', {
+    player = get_player_name(player),
+    target = util.player_list_to_string(targets)
+  })
+end

--- a/plugins/admin/plugin/languages/en.yml
+++ b/plugins/admin/plugin/languages/en.yml
@@ -73,9 +73,13 @@ en:
       description: "Unfreezes a player."
       syntax: "<string player>"
       message: "{player} has unfroze {target}."
+    respawnstay:
+      description: "Respawn a dead player in their death location."
+      syntax: "<string player>"
+      message: "{target} was respawned by {player} in their previous location."
     respawn:
       description: "Respawn a dead player."
-      syntax: "<string player> [tp / stay]"
+      syntax: "<string player>"
       message: "{target} was respawned by {player}."
     godmode:
       description: "Sets god mode to player."


### PR DESCRIPTION
Instead of having 1 command to respawn the player in place there's now 2. One that respawn him in place "/Respawnstay" and one that respawns him in the normal civilian spawn "/Respawn"