### PR TITLE
Fixing a bug where you can't do /fall and fall for an unlimited amount of time

### DIFF
--- a/plugins/ragdoll/plugin/commands/sh_fall.lua
+++ b/plugins/ragdoll/plugin/commands/sh_fall.lua
@@ -8,6 +8,11 @@ COMMAND.no_console = true
 function COMMAND:on_run(player, delay)
   delay = math.clamp(tonumber(delay) or 0, 0, 60)
 
+  if delay > 0 and delay < 2 then
+    player:notify('error.cant_now')
+    return
+  end
+
   if player:Alive() and !player:is_ragdolled() then
     player:set_ragdoll_state(RAGDOLL_FALLENOVER)
 

--- a/plugins/ragdoll/plugin/commands/sh_fall.lua
+++ b/plugins/ragdoll/plugin/commands/sh_fall.lua
@@ -6,7 +6,7 @@ COMMAND.aliases = { 'fallover', 'charfallover' }
 COMMAND.no_console = true
 
 function COMMAND:on_run(player, delay)
-  delay = math.clamp(tonumber(delay) or 0, 2, 60)
+  delay = math.clamp(tonumber(delay) or 0, 0, 60)
 
   if player:Alive() and !player:is_ragdolled() then
     player:set_ragdoll_state(RAGDOLL_FALLENOVER)

--- a/plugins/ragdoll/plugin/commands/sh_fall.lua
+++ b/plugins/ragdoll/plugin/commands/sh_fall.lua
@@ -9,7 +9,7 @@ function COMMAND:on_run(player, delay)
   delay = math.clamp(tonumber(delay) or 0, 0, 60)
 
   if delay > 0 and delay < 2 then
-    player:notify('error.cant_now')
+    player:run_command('fall '..tostring(2))
     return
   end
 


### PR DESCRIPTION
The /fall command immediately made you get up after running it as the minimum time was 2 seconds. Now writing /fall can put you into the ragdoll state indefinitely until the command /getup is ran.