### PR TITLE
Adding a warn command

### DIFF
--- a/plugins/admin/plugin/commands/sh_warn.lua
+++ b/plugins/admin/plugin/commands/sh_warn.lua
@@ -1,0 +1,28 @@
+COMMAND.name = 'Warn'
+COMMAND.description = 'command.warn.description'
+COMMAND.syntax = 'command.warn.syntax'
+COMMAND.permission = 'assistant'
+COMMAND.category = 'permission.categories.player_management'
+COMMAND.arguments = 1
+COMMAND.immunity = true
+COMMAND.aliases = { 'plywarn', 'warn' }
+
+function COMMAND:on_run(player, targets, ...)
+  local reason = table.concat({ ... }, ' ')
+
+  if !reason or reason == '' then
+    player:notify('This is not a valid reason!')
+  else
+    self:notify_staff('command.warn.message', {
+    player = get_player_name(player),
+    target = util.player_list_to_string(targets),
+    reason = reason
+   })
+
+    for k, v in ipairs(targets) do
+     v:notify( "notification.warn", { 
+       reason = reason 
+       })
+    end
+  end
+end

--- a/plugins/admin/plugin/commands/sh_warn.lua
+++ b/plugins/admin/plugin/commands/sh_warn.lua
@@ -21,7 +21,7 @@ function COMMAND:on_run(player, targets, ...)
 
     for k, v in ipairs(targets) do
       v:notify( "notification.warn", { 
-       reason = reason 
+        reason = reason 
       })
     end
   end

--- a/plugins/admin/plugin/commands/sh_warn.lua
+++ b/plugins/admin/plugin/commands/sh_warn.lua
@@ -13,16 +13,16 @@ function COMMAND:on_run(player, targets, ...)
   if !reason or reason == '' then
     player:notify('This is not a valid reason!')
   else
-    self:notify_staff('command.warn.message', {
+   self:notify_staff('command.warn.message', {
     player = get_player_name(player),
     target = util.player_list_to_string(targets),
     reason = reason
    })
 
     for k, v in ipairs(targets) do
-     v:notify( "notification.warn", { 
+      v:notify( "notification.warn", { 
        reason = reason 
-       })
+      })
     end
   end
 end

--- a/plugins/admin/plugin/commands/sh_warn.lua
+++ b/plugins/admin/plugin/commands/sh_warn.lua
@@ -14,10 +14,10 @@ function COMMAND:on_run(player, targets, ...)
     player:notify('This is not a valid reason!')
   else
     self:notify_staff('command.warn.message', {
-    player = get_player_name(player),
-    target = util.player_list_to_string(targets),
-    reason = reason
-   })
+      player = get_player_name(player),
+      target = util.player_list_to_string(targets),
+      reason = reason
+    })
 
     for k, v in ipairs(targets) do
       v:notify( "notification.warn", { 

--- a/plugins/admin/plugin/commands/sh_warn.lua
+++ b/plugins/admin/plugin/commands/sh_warn.lua
@@ -13,7 +13,7 @@ function COMMAND:on_run(player, targets, ...)
   if !reason or reason == '' then
     player:notify('This is not a valid reason!')
   else
-   self:notify_staff('command.warn.message', {
+    self:notify_staff('command.warn.message', {
     player = get_player_name(player),
     target = util.player_list_to_string(targets),
     reason = reason

--- a/plugins/admin/plugin/languages/en.yml
+++ b/plugins/admin/plugin/languages/en.yml
@@ -34,7 +34,7 @@ en:
     warn:
       description: Warns a player.
       syntax: <target> [reason]
-      message: "{player} has warned {target} for {reason}"
+      message: "{player} has warned {target} for {reason}."
     restart:
       description: Restarts the current map.
       syntax: "[number Delay]"

--- a/plugins/admin/plugin/languages/en.yml
+++ b/plugins/admin/plugin/languages/en.yml
@@ -31,6 +31,10 @@ en:
       description: Kicks player from the server.
       syntax: <target> [reason]
       message: "{player} has kicked {target} ({reason})."
+    warn:
+      description: Warns a player.
+      syntax: <target> [reason]
+      message: "{player} has warned {target} for {reason}"
     restart:
       description: Restarts the current map.
       syntax: "[number Delay]"
@@ -106,6 +110,7 @@ en:
       disabled: You are now unvanished.
     freeze: "You've been frozen by {player}."
     unfreeze: "You've been unfrozen by {player}."
+    warn: "You have been warned for {reason}."
     godmode:
       enabled: "God mode enabled."
       disabled: "God mode disabled."


### PR DESCRIPTION
Warns a player to not do something, example:-

Staff runs: /Warn price mingerunning
player receives: "You've been warned for mingerunning."
Other staff see: "X has warned price for mingerunning."