### PR TITLE
Fixing scaling issues

### DIFF
--- a/crates/flow/lib/cl_font.lua
+++ b/crates/flow/lib/cl_font.lua
@@ -28,8 +28,12 @@ function Font.size(name, size, data)
 
   local new_name = name
 
-  if !string.match(new_name, ':(%d)') then
+  local raw_name, original_size = string.match(new_name, '^(.+):(%d)')
+
+  if !original_size then
     new_name = new_name..':'..size
+  else
+    new_name = raw_name..':'..size
   end
 
   if !stored[new_name] then

--- a/crates/flow/views/base/cl_button.lua
+++ b/crates/flow/views/base/cl_button.lua
@@ -44,13 +44,14 @@ end
 
 function PANEL:SizeToContentsX()
   local w, h = util.text_size(self.title, self.font)
+  local offset = self.text_offset or 0
   local add = 0
 
   if self.icon then
     add = h * 1.5 - 2
   end
 
-  self:SetWide(w * 1.15 + add)
+  self:SetWide(w * 1.15 + add + offset)
 end
 
 function PANEL:SizeToContentsY()

--- a/crates/flow/views/cl_scoreboard.lua
+++ b/crates/flow/views/cl_scoreboard.lua
@@ -27,7 +27,7 @@ function PANEL:rebuild()
   end
 
   local cur_y = math.scale(40)
-  local card_tall = math.scale(32) + 8
+  local card_tall = math.scale(32) + math.scale(8)
   local margin = math.scale(2)
 
   for k, v in ipairs(_player.all()) do
@@ -78,7 +78,7 @@ function PANEL:rebuild()
   local player = self.player
 
   self.avatar_panel = vgui.Create('fl_avatar_panel', self)
-  self.avatar_panel:set_size_ex(math.scale_size(32, 32))
+  self.avatar_panel:SetSize(math.scale_size(32, 32))
   self.avatar_panel:SetPos(math.scale_size(4, 4))
   self.avatar_panel:set_player(player, 64)
 

--- a/plugins/sh_weaponselect.lua
+++ b/plugins/sh_weaponselect.lua
@@ -109,7 +109,7 @@ function PLUGIN:HUDPaint()
         color = Theme.get_color('accent')
       end
 
-      surface.draw_text_scaled((IsValid(v.weapon) and v.weapon:GetPrintName():utf8upper()) or 'UNKNOWN WEAPON', Theme.get_font('text_normal_large'), v.x, v.y, v.scale, color)
+      surface.draw_text_scaled((IsValid(v.weapon) and v.weapon:GetPrintName():utf8upper()) or 'UNKNOWN WEAPON', Font.size(Theme.get_font('text_normal_large'), 36), v.x, v.y, v.scale, color)
     end
 
     render.SetScissorRect(0, 0, 0, 0, false)


### PR DESCRIPTION
Were changed:

- Scoreboard avatar icon scaling (it was scaled two times that make it not fit into the player's card)
- SizeToContentsX for fl_button (it worked wrong there were specified non zero set_text_offset)
- Font.size (it didn't work for already scaled font's names like 'flRoboto:21')
- WeaponSelect (temporary fix for overlapping weapon names on high-res screens, removing font scaling)

There are two changes that must be deliberately validated: SizeToContentsX and Font.size functions as they are core functions