### PR TITLE
Considering has_gender and has_name values when player is creating a character

### DIFF
--- a/plugins/characters/plugin/views/cl_character_general.lua
+++ b/plugins/characters/plugin/views/cl_character_general.lua
@@ -124,22 +124,6 @@ function PANEL:Init()
   self.models_list:SetVisible(false)
   self.models_list.Paint = function() end
 
-  if !faction_table.has_gender then
-    self.gender_label:SetVisible(false)
-    self.gender_female:SetVisible(false)
-    self.gender_male:SetVisible(false)
-  end
-
-  if !faction_table.has_description then
-    self.desc_label:SetVisible(false)
-    self.desc_entry:SetVisible(false)
-  end
-
-  if !faction_table.has_name then
-    self.name_label:SetVisible(false)
-    self.name_entry:SetVisible(false)
-  end
-
   self.model = vgui.Create('DModelPanel', self)
   self.model:SetPos(scrw * 0.25 + 32, 32)
   self.model:SetSize(scrw * 0.25, scrh * 0.5 - 36)
@@ -182,6 +166,29 @@ function PANEL:Init()
 
     self.model.Entity:SetSkin(value - 1)
   end
+
+  if !faction_table.has_gender then
+    self.gender_label:SetVisible(false)
+    self.gender_female:SetVisible(false)
+    self.gender_male:SetVisible(false)
+
+    self:GetParent().char_data.gender = 'universal'
+    self:rebuild_models()
+  end
+
+  if !faction_table.has_description then
+    self.desc_label:SetVisible(false)
+    self.desc_entry:SetVisible(false)
+  end
+
+  if !faction_table.has_name then
+    self.name_label:SetVisible(false)
+    self.name_entry:SetVisible(false)
+    if self.name_random then
+      self.name_random:SetVisible(false)
+    end
+  end
+
 end
 
 function PANEL:rebuild_models()

--- a/plugins/characters/plugin/views/cl_character_general.lua
+++ b/plugins/characters/plugin/views/cl_character_general.lua
@@ -184,6 +184,7 @@ function PANEL:Init()
   if !faction_table.has_name then
     self.name_label:SetVisible(false)
     self.name_entry:SetVisible(false)
+
     if self.name_random then
       self.name_random:SetVisible(false)
     end

--- a/plugins/factions/plugin/sv_hooks.lua
+++ b/plugins/factions/plugin/sv_hooks.lua
@@ -46,7 +46,7 @@ end
 
 function Factions:PreCreateCharacter(player, data)
   local faction_table = Factions.find_by_id(data.faction)
-  if faction_table and (!data.name or !string.presence(data.name)) then
+  if faction_table and !string.presence(data.name) then
     -- Try to generate the name if one is not present
     data.name = faction_table:generate_name(player, data.rank or 1)
   end

--- a/plugins/factions/plugin/sv_hooks.lua
+++ b/plugins/factions/plugin/sv_hooks.lua
@@ -44,6 +44,14 @@ function Factions:CharacterGenderChanged(player, char, new_gender, old_gender)
   Characters.set_model(player, player:get_faction():get_random_model(player))
 end
 
+function Factions:PreCreateCharacter(player, data)
+  local faction_table = Factions.find_by_id(data.faction)
+  if faction_table and (!data.name or !string.presence(data.name)) then
+    -- Try to generate the name if one is not present
+    data.name = faction_table:generate_name(player, data.rank or 1)
+  end
+end
+
 function Factions:PlayerCreateCharacter(player, data)
   if !data.faction then
     return CHAR_ERR_FACTION

--- a/plugins/factions/plugin/sv_hooks.lua
+++ b/plugins/factions/plugin/sv_hooks.lua
@@ -46,6 +46,7 @@ end
 
 function Factions:PreCreateCharacter(player, data)
   local faction_table = Factions.find_by_id(data.faction)
+  
   if faction_table and !string.presence(data.name) then
     -- Try to generate the name if one is not present
     data.name = faction_table:generate_name(player, data.rank or 1)


### PR DESCRIPTION
Changes:

- Now if chosen faction has no gender then it will be set universal and model's list will be rebuilt (literally drawn for the first time) during panel initialization. As rebuild_models() requires all other panels to be initialized, has_gender check was moved to the end of the function as well as other conditions to keep the style.  Also random name button is hidden if has_name == false. 

- Flux will now attempt to generate name if it wasn't provided (mostly for cases when has_name == false)

I am not very sure whether those changes are appropriate but they were required when I tried to create faction without gender and name.