### PR TITLE
Ragdoll plugin changes

### DIFF
--- a/plugins/ragdoll/plugin/config/config.yml
+++ b/plugins/ragdoll/plugin/config/config.yml
@@ -1,0 +1,13 @@
+categories:
+  ragdoll:
+    name: config.ragdoll.title
+    description: config.ragdoll.desc
+configs:
+  corpse_remove_delay:
+    name: config.ragdoll.corpse_remove_delay.name
+    description: config.ragdoll.corpse_remove_delay.desc
+    category: ragdoll
+    type: number
+    min_value: 0
+    max_value: 3600
+    default_value: 120

--- a/plugins/ragdoll/plugin/config/config.yml
+++ b/plugins/ragdoll/plugin/config/config.yml
@@ -3,7 +3,7 @@ categories:
     name: config.ragdoll.title
     description: config.ragdoll.desc
 configs:
-  corpse_remove_delay:
+  corpse_decay_time:
     name: config.ragdoll.corpse_remove_delay.name
     description: config.ragdoll.corpse_remove_delay.desc
     category: ragdoll

--- a/plugins/ragdoll/plugin/languages/en.yml
+++ b/plugins/ragdoll/plugin/languages/en.yml
@@ -17,3 +17,10 @@ en:
   ui:
     hud:
       press_jump_to_getup: Press the 'jump' key to get up...
+  config:
+    ragdoll:
+      title: Ragdoll
+      desc: Ragdoll plugin settings.
+      corpse_remove_delay:
+        name: Corpse removement delay
+        desc: Amount of time in seconds before corpse ragdoll will be removed.

--- a/plugins/ragdoll/plugin/languages/ru.yml
+++ b/plugins/ragdoll/plugin/languages/ru.yml
@@ -17,3 +17,10 @@ ru:
   ui:
     hud:
       press_jump_to_getup: Нажмите 'прыжок', чтобы встать...
+  config:
+    ragdoll:
+      title: Ragdoll
+      desc: Настройки плагина Ragdoll.
+      corpse_remove_delay:
+        name: Время удаления ragdoll'а после смерти
+        desc: Время в секундах, которое должно пройти после смерти персонажа, чтобы ragdoll его трупа был удалён.

--- a/plugins/ragdoll/plugin/sv_hooks.lua
+++ b/plugins/ragdoll/plugin/sv_hooks.lua
@@ -1,8 +1,8 @@
 function PLUGIN:PlayerDeath(player)
-  local delay = math.max(Config.get('corpse_remove_delay'), Config.get('respawn_delay'))
+  local decay_time = math.max(Config.get('corpse_decay_time'), Config.get('respawn_delay'))
 
   local settings = {}
-  settings.delay = delay
+  settings.decay_time = decay_time
 
   player:reset_action()
   player:set_ragdoll_state(RAGDOLL_DUMMY, settings)

--- a/plugins/ragdoll/plugin/sv_hooks.lua
+++ b/plugins/ragdoll/plugin/sv_hooks.lua
@@ -1,6 +1,11 @@
 function PLUGIN:PlayerDeath(player)
+  local delay = math.max(Config.get('corpse_remove_delay'), Config.get('respawn_delay'))
+
+  local settings = {}
+  settings.delay = delay
+
   player:reset_action()
-  player:set_ragdoll_state(RAGDOLL_DUMMY)
+  player:set_ragdoll_state(RAGDOLL_DUMMY, settings)
 end
 
 function PLUGIN:PlayerSpawn(player)

--- a/plugins/ragdoll/plugin/sv_plugin.lua
+++ b/plugins/ragdoll/plugin/sv_plugin.lua
@@ -104,6 +104,7 @@ function player_meta:create_ragdoll_entity(decay_time, fallen)
         end
       end
     end
+    
     self:SetDTEntity(ENT_RAGDOLL, ragdoll)
   end
 end

--- a/plugins/ragdoll/plugin/sv_plugin.lua
+++ b/plugins/ragdoll/plugin/sv_plugin.lua
@@ -20,7 +20,7 @@ function player_meta:is_ragdolled()
   return false
 end
 
-function player_meta:create_ragdoll_entity(delay, fallen)
+function player_meta:create_ragdoll_entity(decay_time, fallen)
   if !IsValid(self:GetDTEntity(ENT_RAGDOLL)) then
     local ragdoll = ents.Create('prop_ragdoll')
       ragdoll:SetModel(self:GetModel())
@@ -29,7 +29,7 @@ function player_meta:create_ragdoll_entity(delay, fallen)
       ragdoll:SetSkin(self:GetSkin())
       ragdoll:SetMaterial(self:GetMaterial())
       ragdoll:SetColor(self:GetColor())
-      ragdoll.delay = delay
+      ragdoll.decay_time = decay_time
       ragdoll.weapons = {}
     ragdoll:Spawn()
 
@@ -73,8 +73,8 @@ function player_meta:create_ragdoll_entity(delay, fallen)
       self:SetNotSolid(true)
     end
 
-    if delay then
-      timer.Simple(delay, function()
+    if decay_time then
+      timer.Simple(decay_time, function()
         if IsValid(ragdoll) then
           -- Reset player's ragdoll state
           -- If he is still on the server and owns the same ragdoll
@@ -112,7 +112,7 @@ function player_meta:reset_ragdoll_entity()
   local ragdoll = self:GetDTEntity(ENT_RAGDOLL)
 
   if IsValid(ragdoll) then
-    if !ragdoll.delay then
+    if !ragdoll.decay_time then
       ragdoll:Remove()
     end
 
@@ -130,10 +130,10 @@ function player_meta:set_ragdoll_state(state, settings)
     self:set_action('fallen', true)
     self:create_ragdoll_entity(nil, true)
   elseif state == RAGDOLL_DUMMY then
-    local delay = settings.delay or 120
+    local decay_time = settings.decay_time or 120
 
-    if delay > 0 then
-      self:create_ragdoll_entity(delay)
+    if decay_time > 0 then
+      self:create_ragdoll_entity(decay_time)
     end
   elseif state == RAGDOLL_NONE then
     self:reset_ragdoll_entity()


### PR DESCRIPTION
- Fixed bug
When player leave server after his death, his ragdoll is in not removed as it is done with player:set_ragdoll_state(RAGDOLL_NONE) called in PlayerSpawn hook.
So it was moved into the create_ragdoll_entity function.
- Typo
Decay is a bit ambiguous parameter name, so it was renamed into delay
- Feature
Corpse removement delay was moved into config.yml
- To be negotiated
Is it better to store delay parameter in the separated table that is passed to set_ragdoll_state as parameter or initialize it directly in this method
Also, whether there are any others way to call PlayerDeathThink hook without calling player:is_ragdolled() method, that would allow to delete corpses before player respawned

PS sorry for the messy first pull request. 
