### PR TITLE
fix class super

### DIFF
--- a/lib/stdlib/sh_class.lua
+++ b/lib/stdlib/sh_class.lua
@@ -67,7 +67,7 @@ function class(name, parent_class)
         return parent_class.init(new_obj, ...)
       end
 
-      real_class.init = isfunction(real_class.init) and real_class.init or function(obj) super() end
+      real_class.init = isfunction(real_class.init) and real_class.init or function(obj, ...) super(...) end
     end
 
     -- If there is a constructor - call it.


### PR DESCRIPTION
'super' doesn't work properly

e.g.:
```lua
class "A"
A.a = "a"
A.init = function(self, arg)
 print(arg, self.a)
end

class "B" extends "A"
B.a = "b"

test = B.new "arg" --> nil, b
-- expected: arg, b
```