### PR TITLE
fix msg type conversion

### DIFF
--- a/lib/stdlib/sh_utils.lua
+++ b/lib/stdlib/sh_utils.lua
@@ -332,7 +332,7 @@ end
 
 --- Print an error message followed by a complete stack traceback.
 function error_with_traceback(msg)
-  long_error(msg..'\n')
+  long_error(tostring(msg)..'\n')
   print_traceback()
 end
 


### PR DESCRIPTION
msg should always be a string